### PR TITLE
Minor Spacing.

### DIFF
--- a/enum.cpp
+++ b/enum.cpp
@@ -2,17 +2,23 @@
 #include <stdlib.h>
 using namespace std;
 
-enum Company{
-	Google = 1, Facebook, Twitter, Snapdeal, Microsoft
+enum Company {
+	Google = 1, 
+	Facebook, 
+	Twitter, 
+	Snapdeal, 
+	Microsoft
 };
 
-int main(int argc, char const *argv[]){
+int main(int argc, char const *argv[]) {
 	
 	int choice;
+	
 	repeat:
 	cout << "Please enter a choice : ";
 	cin >> choice;
-	switch(choice){
+	
+	switch(choice) {
 		case Google: 
 				cout << "You have chosen Google.";
 				break;
@@ -33,6 +39,7 @@ int main(int argc, char const *argv[]){
 				goto repeat;
 			break;	
 	}
-
+	
 	return 0;
+	
 }


### PR DESCRIPTION
Edited to show enum cases should be written in multiple lines so that cases can be shown in a better way.