### PR TITLE
removed goto statement

### DIFF
--- a/decToBin.cpp
+++ b/decToBin.cpp
@@ -75,14 +75,13 @@ int main(int argc, char const *argv[]){
 	float number;
 	cout << "\t\t******* CONVERTER ********\n\n";
 
-	check:
 	cout << "\tEnter the number: ";
 	cin >> number;
-	
-	if (number < 0){
+	while(number<0){
 		cerr << "\tERROR: Please enter a positive number.\n";
-		goto check;
+		cin>>number;
 	}
+	
 
 	cout<<"\tYou have entered "<<number<<"\n\n";
 	object.convertDecimalToBinary(number);


### PR DESCRIPTION
It is a standard practice to never use goto in cpp code because it breaks the natural sequential flow of the code. This minor update is an alternative to goto statement that was used.